### PR TITLE
Refactor for null-safety, resource cleanup, modern syntax

### DIFF
--- a/Drill Namer.csproj
+++ b/Drill Namer.csproj
@@ -61,15 +61,6 @@
     <Reference Include="acmgd">
       <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2022\acmgd.dll</HintPath>
     </Reference>
-    <Reference Include="Autodesk.AutoCAD.Interop">
-      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2022\Autodesk.AutoCAD.Interop.dll</HintPath>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Autodesk.AutoCAD.Interop.Common, Version=24.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\..\..\..\..\..\Program Files\Autodesk\AutoCAD 2022\Autodesk.AutoCAD.Interop.Common.dll</HintPath>
-    </Reference>
     <Reference Include="PresentationCore" />
     <Reference Include="System" />
     <Reference Include="System.Configuration" />


### PR DESCRIPTION
## Summary
- add utility helpers for showing alerts and checking layers
- remove obsolete AutoCAD Interop references
- refactor COMPLETE CORDS workflow into smaller helpers
- use interpolation and `var` for cleaner syntax

## Testing
- `bash setup.sh` *(fails: CONNECT tunnel failed)*


------
https://chatgpt.com/codex/tasks/task_e_684848c394248322a92e50189578ca76